### PR TITLE
Use min SDK version 17

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.codepath.apps.restclienttemplate"
-        minSdkVersion 16
+        minSdkVersion 17
         targetSdkVersion 25
     }
 


### PR DESCRIPTION
ConstraintLayout issues a bunch of warnings about native RTL support (https://android-developers.googleblog.com/2013/03/native-rtl-support-in-android-42.html).  I think we lose 3% of the market but that's OK for training purposes (https://developer.android.com/about/dashboards/index.html)