### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ def dbflow_version = "4.0.0-beta5"
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile 'com.codepath.libraries:android-oauth-handler:1.2.2'
+    compile 'com.codepath.libraries:android-oauth-handler:1.2.3'
     compile 'com.android.support:appcompat-v7:25.2.1'
     // Picasso for remote image loading
     compile 'com.squareup.picasso:picasso:2.5.2'


### PR DESCRIPTION
Bump to 1.2.3 - fixes OAuth1 issue with Twitter (using new Scribe library)