### PR TITLE
simplify AsyncTask to avoid needing to parameterize it

### DIFF
--- a/app/src/main/java/com/codepath/apps/restclienttemplate/LoginActivity.java
+++ b/app/src/main/java/com/codepath/apps/restclienttemplate/LoginActivity.java
@@ -12,15 +12,7 @@ import com.codepath.oauth.OAuthLoginActionBarActivity;
 public class LoginActivity extends OAuthLoginActionBarActivity<RestClient> {
 
 	SampleModelDao sampleModelDao;
-
-	AsyncTask<SampleModel, Void, Void> task = new AsyncTask<SampleModel, Void, Void>() {
-		@Override
-		protected Void doInBackground(SampleModel... sampleModels) {
-			sampleModelDao.insertModel(sampleModels);
-			return null;
-		};
-	};
-
+	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -31,7 +23,12 @@ public class LoginActivity extends OAuthLoginActionBarActivity<RestClient> {
 
 		sampleModelDao = ((RestApplication) getApplicationContext()).getMyDatabase().sampleModelDao();
 
-		task.execute(sampleModel);
+		AsyncTask.execute(new Runnable() {
+			@Override
+			public void run() {
+				sampleModelDao.insertModel(sampleModel);
+			}
+		});
 	}
 
 


### PR DESCRIPTION
Someone had issues trying to use multiple AsyncTasks in the same loop.  Just simplify this code.